### PR TITLE
TII-223: Add cutover date feature to globalpropertyadvisor to aid with transitioning between legacy and LTI integrations

### DIFF
--- a/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
+++ b/assignment/assignment-impl/impl/src/java/org/sakaiproject/assignment/impl/BaseAssignmentService.java
@@ -10933,7 +10933,8 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 					String contentId = cr.getId();
 					try {
 						Site site = SiteService.getSite(m_context);
-						boolean siteCanUseLTIReviewService = contentReviewSiteAdvisor.siteCanUseLTIReviewService(site);
+						Date asnCreationDate = new Date(m_asn.getTimeCreated().getTime());
+						boolean siteCanUseLTIReviewService = contentReviewSiteAdvisor.siteCanUseLTIReviewServiceForAssignment(site, asnCreationDate);
 						if (siteCanUseLTIReviewService) {
 							return contentReviewService.getReviewReport(contentId, null, null);
 						} else {
@@ -10974,7 +10975,8 @@ public abstract class BaseAssignmentService implements AssignmentService, Entity
 				String contentId = cr.getId();
 				try {
 					Site site = SiteService.getSite(m_context);
-					boolean siteCanUseLTIReviewService = contentReviewSiteAdvisor.siteCanUseLTIReviewService(site);
+					Date asnCreationDate = new Date(m_asn.getTimeCreated().getTime());
+					boolean siteCanUseLTIReviewService = contentReviewSiteAdvisor.siteCanUseLTIReviewServiceForAssignment(site, asnCreationDate);
 					if (siteCanUseLTIReviewService) {
 						return contentReviewService.getReviewReport(contentId, null, null);
 					} else {

--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -58,6 +58,7 @@ import java.util.SortedSet;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.Optional;
 
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -1596,14 +1597,16 @@ public class AssignmentAction extends PagedResourceActionII
 			
 			// add TII info if needed
 			Optional<Site> siteOpt = getSiteFromState(state);
-			if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(siteOpt)){
+			AssignmentContent ac = assignment.getContent();
+			if (allowReviewService && ac.getAllowReviewService() && allowLTIReviewService(siteOpt, assignment)){
 				//put the LTI assignment link in context
 				String ltiLink = contentReviewService.getLTIAccess(currentAssignmentReference, contextString);
 				M_log.debug("ltiLink " + ltiLink);
 				context.put("ltiLink", ltiLink);
-				int maxPointsInt = assignment.getContent().getMaxGradePoint() / AssignmentService.getScaleFactor();
+				int maxPointsInt = ac.getMaxGradePoint() / AssignmentService.getScaleFactor();
 				context.put("maxPointsInt", maxPointsInt);
-				if(isDirectAccess(siteOpt) && Boolean.valueOf(AssignmentService.canSubmit(contextString, assignment))){
+
+				if(isDirectAccess(siteOpt, assignment) && Boolean.valueOf(AssignmentService.canSubmit(contextString, assignment))){
 					M_log.debug("Allowing submission directly from TII");
 					String templateAux = (String) getContext(data).get("template");
 					return templateAux + "_lti_access";
@@ -2346,12 +2349,13 @@ public class AssignmentAction extends PagedResourceActionII
 		
 		// add TII info if needed
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state))){
+		AssignmentContent ac = assignment == null ? null : assignment.getContent();
+		if (allowReviewService && ac != null && ac.getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), assignment)){
 			//put the LTI assignment link in context
 			String ltiLink = contentReviewService.getLTIAccess(assignment.getId(), contextString);
 			M_log.debug("ltiLink " + ltiLink);
 			context.put("ltiLink", ltiLink);
-			int maxPointsInt = assignment.getContent().getMaxGradePoint() / AssignmentService.getScaleFactor();
+			int maxPointsInt = ac.getMaxGradePoint() / AssignmentService.getScaleFactor();
 			context.put("maxPointsInt", maxPointsInt);
 		}
 		
@@ -3690,12 +3694,14 @@ public class AssignmentAction extends PagedResourceActionII
 		
 		// add TII info if needed
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		if (allowReviewService && a.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state))){
+
+		AssignmentContent ac = a.getContent();
+		if (allowReviewService && ac.getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), a)){
 			//put the LTI assignment link in context
 			String ltiLink = contentReviewService.getLTIAccess(assignmentId, contextString);
 			M_log.debug("ltiLink " + ltiLink);
 			context.put("ltiLink", ltiLink);
-			int maxPointsInt = a.getContent().getMaxGradePoint() / AssignmentService.getScaleFactor();
+			int maxPointsInt = ac.getMaxGradePoint() / AssignmentService.getScaleFactor();
 			context.put("maxPointsInt", maxPointsInt);
 		}
 		
@@ -4449,14 +4455,16 @@ public class AssignmentAction extends PagedResourceActionII
 		String template = (String) getContext(data).get("template");
 		
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
+
 		Optional<Site> siteOpt = getSiteFromState(state);
-		if (allowReviewService && assignment != null && assignmentContent != null && assignmentContent.getAllowReviewService() && allowLTIReviewService(siteOpt)){
+		if (allowReviewService && assignment != null && assignmentContent != null && assignmentContent.getAllowReviewService() && allowLTIReviewService(siteOpt, assignment)){
 			String ltiLink = contentReviewService.getLTIAccess(assignmentRef, contextString);
 			M_log.debug("ltiLink " + ltiLink);
 			context.put("ltiLink", ltiLink);
 			int maxPointsInt = assignmentContent.getMaxGradePoint() / AssignmentService.getScaleFactor();
 			context.put("maxPointsInt", maxPointsInt);
-			if(isDirectAccess(siteOpt)){
+
+			if(isDirectAccess(siteOpt, assignment)){
 				M_log.debug("Allowing submission directly from TII");
 				return template + "_lti_access";
 			}
@@ -4569,7 +4577,7 @@ public class AssignmentAction extends PagedResourceActionII
 		context.put("honor_pledge_text", ServerConfigurationService.getString("assignment.honor.pledge", rb.getString("gen.honple2")));
 		
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state))){
+		if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), assignment)){
 			//put the LTI assignment link in context
 			String ltiLink = contentReviewService.getLTIAccess(assignmentId, contextString);
 			M_log.debug("ltiLink " + ltiLink);
@@ -7458,7 +7466,16 @@ public class AssignmentAction extends PagedResourceActionII
 				addAlert(state, rb.getString("gen.cr.submit"));
 			}
 
-			if (allowReviewService && allowLTIReviewService(Optional.ofNullable(st)) && validify){
+			Assignment asn = null;
+			try
+			{
+				asn = AssignmentService.getAssignment(assignmentRef);
+			}
+			catch (IdUnusedException | PermissionException e)
+			{
+				// do nothing, will check for null later
+			}
+			if (allowReviewService && st != null && asn != null && allowLTIReviewService(Optional.of(st), asn) && validify){
 				if (title != null && contentreviewAssignMin > 0 && title.length() < contentreviewAssignMin){
 					// if the title is shorter than the minimum post the message
 					// One could ignore the message and still post the assignment
@@ -10400,7 +10417,7 @@ public class AssignmentAction extends PagedResourceActionII
 				state.setAttribute(STATE_MODE, MODE_INSTRUCTOR_NEW_EDIT_ASSIGNMENT);
 				
 				// generate alert when editing an assignment from old site
-				if(allowReviewService && allowLTIReviewService(getSiteFromState(state)) && a.getContent().getAllowReviewService()){
+				if(allowReviewService && allowLTIReviewService(getSiteFromState(state), a) && a.getContent().getAllowReviewService()){
 					String reviewServiceName = contentReviewService.getServiceName();
 					if (contentreviewAssignMin > 0 && a.getTitle().length() < contentreviewAssignMin){
 						addAlert(state, rb.getFormattedMessage("review.assignchars", new Object[]{reviewServiceName, contentreviewAssignMin}));
@@ -11894,7 +11911,8 @@ public class AssignmentAction extends PagedResourceActionII
 	 */
 	private void removeLTITool(SessionState state, AssignmentEdit aEdit){
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		if (allowReviewService && aEdit.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state))){
+
+		if (allowReviewService && aEdit.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), aEdit)){
 			//put the LTI assignment link in context
 			boolean removed = contentReviewService.deleteLTITool(aEdit.getReference(), contextString);
 			if(!removed){
@@ -18080,15 +18098,29 @@ public class AssignmentAction extends PagedResourceActionII
 			}
 		}
 	}
-	
-	private boolean allowLTIReviewService(Optional<Site> siteOpt)
+
+	// this method is transitional and should be removed when TII legacy api support ends
+	private boolean allowLTIReviewService(Optional<Site> siteOpt, Assignment assignment)
 	{
-		return siteOpt.map(s -> contentReviewSiteAdvisor.siteCanUseLTIReviewService(s)).orElse(false);
+		if (assignment == null)
+		{
+			return false;
+		}
+		
+		return siteOpt.map(s -> contentReviewSiteAdvisor.siteCanUseLTIReviewServiceForAssignment(s, new Date(assignment.getTimeCreated().getTime())))
+				.orElse(false);
 	}
 	
-	private boolean isDirectAccess(Optional<Site> siteOpt)
+	// this method is transitional and (at least the Assignment argument) should be removed when TII legacy support ends
+	private boolean isDirectAccess(Optional<Site> siteOpt, Assignment assignment)
 	{
-		return siteOpt.map(s -> contentReviewService.isDirectAccess(s)).orElse(false);
+		if (assignment == null)
+		{
+			return false;
+		}
+		
+		return siteOpt.map(s -> contentReviewService.isDirectAccess(s, new Date(assignment.getTimeCreated().getTime())))
+				.orElse(false);
 	}
 	
 	private Optional<Site> getSiteFromState(SessionState state)

--- a/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
+++ b/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
@@ -257,6 +257,16 @@ public interface ContentReviewService {
 	public boolean isDirectAccess(Site s);
 	
 	/**
+	 * Version of the above method compatible with date-aware site advisors. This is a transitional
+	 * method that should be removed when TII legacy api support ends
+	 * @param s
+	 * @param assignmentCreationDate
+	 * @return 
+	 */
+	@Deprecated
+	public boolean isDirectAccess(Site s, Date assignmentCreationDate);
+	
+	/**
 	 *  Get a icon URL that for a specific score
 	 * @param score
 	 * @return

--- a/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewSiteAdvisor.java
+++ b/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewSiteAdvisor.java
@@ -1,5 +1,6 @@
 package org.sakaiproject.contentreview.service;
 
+import java.util.Date;
 import org.sakaiproject.site.api.Site;
 
 public interface ContentReviewSiteAdvisor {
@@ -8,6 +9,17 @@ public interface ContentReviewSiteAdvisor {
 	public boolean siteCanUseReviewService(Site site);
 
 	public boolean siteCanUseLTIReviewService(Site site);
+
+	/**
+	 * Returns true if the TII LTI review service should be used, given the
+	 * assignment creation date. This is a transitional method that should be removed
+	 * once TII legacy api support ends.
+	 * @param site
+	 * @param assignmentCreationDate
+	 * @return 
+	 */
+	@Deprecated
+	public boolean siteCanUseLTIReviewServiceForAssignment(Site site, Date assignmentCreationDate);
 
 	public boolean siteCanUseLTIDirectSubmission(Site site);
 }

--- a/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
+++ b/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
@@ -315,6 +315,13 @@ public class ContentReviewFederatedServiceImpl implements ContentReviewService {
 			return provider.isDirectAccess(arg0);
 		return false;
 	}
+	
+	public boolean isDirectAccess(Site arg0, Date asnCreationDate) {
+		ContentReviewService provider = getSelectedProvider();
+		if (provider != null)
+			return provider.isDirectAccess(arg0, asnCreationDate);
+		return false;
+	}
 
 	public void processQueue() {
 		ContentReviewService provider = getSelectedProvider();


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-223

At Western we have developed and deployed a simple way to transition over to the LTI integration. By adding a cutover date property to the global site advisor and setting the date to match that of our deployment, we have a system where any Turnitin assignments created prior to the deployment will continue to use the legacy integration, while all newly created assignments will use the LTI integration. This also allows a site to use both types of integration at the same time. A single point-in-time cutover can easily be communicated to instructors and does not require any intervention by system administrators.

This patch provides this implementation, along with making the globalpropertyadvisor the default content review site advisor.

The cutover date property is:

assignment.useContentReviewLTICutoverDate=2016-SEP-02

The date format must match the example above (yyyy-MMM-dd). If the property is not set or is set incorrectly, behaviour falls back to the original globalpropertyadvisor logic.
