### PR TITLE
TII-228 - added mechanism to append the ID of a resource to LTI URLs, this way lti_content instances can be re-used for multiple resources within a site. Otherwise we would have a one-to-one for, say, AssignmentAubmissions to Turnitin originality report URLs

### DIFF
--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -831,6 +831,7 @@ public interface LTIService {
 	static final String LTI_STATUS = 	"status";
 	static final String LTI_VISIBLE = 	"visible";
 	static final String LTI_LAUNCH = 	"launch";
+	static final String LTI_LAUNCHSUFFIX = 	"launch_suffix";
 	static final String LTI_ALLOWLAUNCH = 	"allowlaunch";
 	static final String LTI_CONSUMERKEY= 	"consumerkey";
 	static final String LTI_ALLOWCONSUMERKEY= 	"allowconsumerkey";

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -773,6 +773,12 @@ public class SakaiBLTIUtil {
 		if ( launch_url == null ) launch_url = (String) tool.get(LTIService.LTI_LAUNCH);
 		if ( launch_url == null ) return postError("<p>" + getRB(rb, "error.nolaunch" ,"This tool is not yet configured.")+"</p>" );
 
+		String launchSuffix = (String)content.get(LTIService.LTI_LAUNCHSUFFIX);
+		if (launchSuffix != null)
+		{
+			launch_url = launch_url + launchSuffix;
+		}
+
 		String context = (String) content.get(LTIService.LTI_SITE_ID);
 		Site site = null;
 		try {

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/basiclti/impl/BasicLTISecurityServiceImpl.java
@@ -333,7 +333,24 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 					Map<String,Object> content = null;
 					Map<String,Object> tool = null;
 
-					String contentStr = refId.substring(8);
+					// see if a resource has been passed into the URL
+					String resourcePattern = ",resource:";
+					int resourcePatternIndex = refId.indexOf(resourcePattern);
+					String resource = null;
+					String contentStr = null;
+					if (resourcePatternIndex != -1)
+					{
+						// resource is passed in. resource = everything after the resourcePattern
+						resource = refId.substring(resourcePatternIndex + resourcePattern.length());
+						// contentStr = everything between "content:" and resourcePattern
+						contentStr = refId.substring(8, resourcePatternIndex);
+					}
+					else
+					{
+						// No resource passed in; just grab everything after "content:"
+						contentStr = refId.substring(8);
+					}
+
 					Long contentKey = foorm.getLongKey(contentStr);
 					if ( contentKey >= 0 )
 					{
@@ -358,10 +375,16 @@ public class BasicLTISecurityServiceImpl implements EntityProducer {
 								{
 									logger.warn("SiteId is not context: " + siteId + " - " + ref.getContext());
 									String turnitinSite = ServerConfigurationService.getString("turnitin.lti.site", "!turnitin");
-									if(!siteId.equals(turnitinSite)){
+									String turnitinReportsSite = ServerConfigurationService.getString("turnitin.ltireports.site", "!turnitin_reports");
+									if(!siteId.equals(turnitinSite) && !siteId.equals(turnitinReportsSite)){
 										tool = null;
 									}
 								}
+							}
+
+							if (resource != null)
+							{
+								content.put(LTIService.LTI_LAUNCHSUFFIX, resource);
 							}
 						}
 


### PR DESCRIPTION
Linking users directly to originality reports was a behavior that existed in Sakai10
Turnitin has endpoints to access papers directly:
https://sandbox.turnitin.com/api/lti/1p0/dv/report/
https://api.turnitin.com/api/lti/1p0/dv/report/
https://api.turnitinuk.com/api/lti/1p0/dv/report/ (guessing)

Make originality report icon links take users to these endpoints

Requires another LTI external tool set up similarly to !turnitin, except the "Site Id" is "!turnitin_reports", and the URL is one of the endpoints above.
If requested, I can rework the PRs to introduce a sakai property for this to fall back to the original behavior (always direct users to the landing page for the assignment); but it's my opinion that it's more appropriate to direct users to the originality report of the attachment that was clicked.

Introduces sakai.property:
turnitin.ltireports.site=!turnitin_reports (default)

If merged, the set up documentation should be updated to include instructions to create the !turnitin_reports lti instance in External Tools
