### PR TITLE
TII-239 - Hide InlineSub_ file name on instructor's grading preview screen

### DIFF
--- a/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
+++ b/assignment/assignment-tool/tool/src/webapp/vm/assignment/chef_assignments_instructor_preview_grading_submission.vm
@@ -77,6 +77,50 @@
 						#end
 					</td>
 				</tr>
+				#if ($allowReviewService && $assignment.getContent().AllowReviewService)
+					<tr>
+					<th>
+						$reviewServiceName&nbsp;$tlang.getString("review.report")
+					</th>
+					<td>
+						#set($reviewResults=$submission.ContentReviewResults)
+						#if ($reviewResults.size() >= 3)
+							<div class="discTria">
+								<input class="disclosureTriangle" type="image" onclick="ASN.handleReportsTriangleDisclosure(this, this.parentNode.parentNode.children[1]); return false;" src="/library/image/sakai/expand.gif" alt="$tlang.getString('review.report.expand')"/>
+								$reviewResults.size() $tlang.getString("review.reports")
+							</div>
+							<div id="reportsDiv" style="display:none;">
+						#end
+						#foreach ($reviewResult in $reviewResults)
+							<div>
+								#set ($props = $reviewResult.getContentResource().Properties)
+								<span class="reportIcon">
+									#if ($reviewResult.getReviewReport().equals("Error"))
+										<img src="/library/skin/images/error.png" alt="$reviewResult.getReviewError()" title="$reviewResult.getReviewError()">
+									#else
+										<a href="$reviewResult.getReviewReport()" target="_blank" rel="noreferrer">
+											<img src="$reviewResult.getReviewIconURL()" alt="$reviewResult.getReviewScore()" title="$reviewResult.getReviewScore()">
+										</a>
+									#end
+								</span>
+								#if ($reviewResult.isInline())
+									$tlang.getString("submission.inline")
+								#else
+									$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))
+								#end
+								#if($reviewResult.getExternalGrade() && $assignment.getContent().AllowStudentViewExternalGrade)
+									<span style="font-style:italic !important">
+										($tlang.getString("gen.gra.ext") $reviewResult.getExternalGrade() / $maxPointsInt)
+									</span>
+								#end
+							</div>
+						#end
+						#if ($reviewResults.size() >= 3)
+							</div>
+						#end
+					</td>
+				#end
+
 			</table>
 			<h4>
 				$tlang.getString("gen.instr")
@@ -133,30 +177,45 @@
 			#end
 			#if ($size == 0)
 			#else
-				<h4>
-					#if ($submissionType == 5)
-						$tlang.getString("gen.stuatt.single")
-					#else
-						$tlang.getString("gen.stuatt")
-					#end
-				</h4>	
-				<ul class="attachList indnt1">
-					#foreach ($attachment in $submission.SubmittedAttachments) 
-						#set ($props = false)
-						#set ($props = $attachment.Properties) 
-						#if ($!props)
-							<li>
-								#if ($props.getBooleanProperty($props.NamePropIsCollection))
-									<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
-								#else
-									<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
-								#end
-								<a href="$attachment.Url" target="_blank">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>						
-								#propertyDetails($props)
-							</li>
+				#set ($attachAllowed = $submissionType != 1 && $submissionType != 4)
+				#if ($attachAllowed || $size != 0) ##do not show attach messages if no attach are allowed unless an attach is present anyway.
+					<h3>
+						#if ($submissionType == 5)
+							$tlang.getString("gen.stuatt.single")
+						#else
+							$tlang.getString("gen.stuatt")
 						#end
-					#end
-				</ul>
+					</h3>
+				#end
+				#if ($size == 0 && $attachAllowed)
+					## only display in submission types that are supposed to have attachments
+					<p class="text-warning">
+						#if ($submissionType == 5)
+							$tlang.getString("gen.noattsubmitted.single")
+						#else
+							$tlang.getString("gen.noattsubmitted")
+						#end
+					</p>
+				#elseif ($size != 0)
+					## There are attachments. We don't care which submission type it really is, they need to be displayed
+					<ul class="attachList idnt1">
+						#foreach ($attachment in $submission.VisibleSubmittedAttachments)
+							#set ($props = false)
+							#set ($props = $attachment.Properties)
+							#if ($!props)
+								<li>
+									#if ($props.getBooleanProperty($props.NamePropIsCollection))
+										<img src = "#imageLink($contentTypeImageService.getContentTypeImage("folder"))" border="0" alt="$tlang.getString("gen.folatt")" />
+									#else
+										<img src = "#imageLink($contentTypeImageService.getContentTypeImage($props.getProperty($props.NamePropContentType)))" border="0" alt="$tlang.getString("gen.filatt")" />
+									#end
+									<a href="$attachment.Url" target="_blank" rel="noreferrer">$validator.escapeHtml($props.getPropertyFormatted($props.NamePropDisplayName))</a>
+									#propertyDetails($props)
+								</li>
+							#end
+						#end
+					</ul>
+				#end
 			#end	
 			#if ($!feedback_comment.length()>0)
 				<h4>$tlang.getString("gen.sumcom")</h4>	


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-239

1) As instructor, view a submission that has inline text submitted to Turnitin
2) At the bottom of this grading page, go to 'Preview'
3) Notice we have an "InlineSub_..." file name. This should read "Inline Submission"

Add a "Turnitin Report" section at the top of the screen like in other views, and hide inline submissions from the Submitted Attachment list.