### PR TITLE
TII-221 - Move turnitin_id attributes on content_resource.binary_entity to contentreview_item.externalId

### DIFF
--- a/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
+++ b/content-review/content-review-api/public/src/java/org/sakaiproject/contentreview/service/ContentReviewService.java
@@ -427,6 +427,14 @@ public interface ContentReviewService {
 	public boolean updateItemAccess(String contentId);
 
 	/**
+	 * Updates the externalId field of the contentreview_item with the specified contentId
+	 * @param contentId the contentId of the contentreview_item to be updated
+	 * @param externalId the ID supplied remotely by the content review servie for this item
+	 * @return whether the update was successful
+	 */
+	public boolean updateExternalId(String contentId, String externalId);
+
+	/**
 	 * Sets the grade for a submission content
 	 *
 	 * @param contentId

--- a/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
+++ b/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
@@ -413,10 +413,13 @@ public class ContentReviewFederatedServiceImpl implements ContentReviewService {
 		return false;
 	}
 
-	public boolean updateExternalId(String contentId, String externalId){
+	public boolean updateExternalId(String contentId, String externalId)
+	{
 		ContentReviewService provider = getSelectedProvider();
 		if (provider != null)
+		{
 			return provider.updateExternalId(contentId, externalId);
+		}
 		return false;
 	}
 

--- a/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
+++ b/content-review/contentreview-federated/impl/src/java/org/sakaiproject/contentreview/impl/ContentReviewFederatedServiceImpl.java
@@ -413,6 +413,13 @@ public class ContentReviewFederatedServiceImpl implements ContentReviewService {
 		return false;
 	}
 
+	public boolean updateExternalId(String contentId, String externalId){
+		ContentReviewService provider = getSelectedProvider();
+		if (provider != null)
+			return provider.updateExternalId(contentId, externalId);
+		return false;
+	}
+
 	public boolean updateExternalGrade(String contentId, String score){
 		ContentReviewService provider = getSelectedProvider();
 		if (provider != null)


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-221

Background:

1. When a student submits an assignment, contentreview_items are created for the attachments.
The Content Review Queue job posts these attachments to Turnitin, turnitin responds whether the post was successful.
2. An asynchronous callback from Turnitin then gives us the "externalId" (the ID of the submitted file on TII's end).
3. The reports job then uses the "externalId" to retrieve Turnitin's originality report
4. Currently step 3 sets the externalId in the content_resource table's binary_entity column. This table represents files on the file system. There already exists an externalId column in contentreview_item specifically for this purpose which we are now just leaving null.

We should move the externalId to contentreview_item as it is a content-review specific datum, and this will make externalIds more searchable.