### PR TITLE
TII-227 - Implement mechanism to determine LTI role (Instructor / Learner) based on asn.grade instead of site.upd

### DIFF
--- a/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
+++ b/assignment/assignment-tool/tool/src/java/org/sakaiproject/assignment/tool/AssignmentAction.java
@@ -4580,7 +4580,9 @@ public class AssignmentAction extends PagedResourceActionII
 		context.put("honor_pledge_text", ServerConfigurationService.getString("assignment.honor.pledge", rb.getString("gen.honple2")));
 		
 		String contextString = (String) state.getAttribute(STATE_CONTEXT_STRING);
-		if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), assignment)){
+		Site site = getSiteOrNull(state);
+		if (allowReviewService && assignment.getContent().getAllowReviewService() && allowLTIReviewService(getSiteFromState(state), assignment)
+			&& m_securityService.unlock(AssignmentService.SECURE_GRADE_ASSIGNMENT_SUBMISSION, site.getReference())){
 			//put the LTI assignment link in context
 			String ltiLink = contentReviewService.getLTIAccess(assignment.getReference(), contextString);
 			M_log.debug("ltiLink " + ltiLink);
@@ -18149,6 +18151,22 @@ public class AssignmentAction extends PagedResourceActionII
 		{
 			M_log.warn("Site not found for id: " + siteId, e);
 			return Optional.empty();
+		}
+	}
+
+	/**
+	 * Convenience method to pull site from the state or null if not found
+	 */
+	private Site getSiteOrNull(SessionState state)
+	{
+		try
+		{
+			return SiteService.getSite((String) state.getAttribute(STATE_CONTEXT_STRING));
+		}
+		catch (IdUnusedException e)
+		{
+			M_log.warn("Site not found for id: " + STATE_CONTEXT_STRING, e);
+			return null;
 		}
 	}
 }	

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIRoleAdvisor.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIRoleAdvisor.java
@@ -1,0 +1,20 @@
+package org.sakaiproject.lti.api;
+
+/**
+ * Functional interface; getLTIRole() retrieves the LTI role (admin / instructor / learner) for the specified context (Ie. siteId of the site hosting this LTI instance), and ltiSiteId (Ie. as specified in External Tools).
+ * This is primarily intended for deep integrations like assignments' LTI integration with Turnitin
+ *
+ * @author bbailla2
+ */
+public interface LTIRoleAdvisor
+{
+	/**
+	 * Resolves the role for the specified userId, context (Ie. site ID of the site hosting this LTI instance), and LTI Site Id as specified in External Tools
+	 * @param userId the user whose LTI role we are retrieving
+	 * @param context the siteId of the site hosting this LTI instance
+	 * @param ltiSiteId the site ID of the LTI tool as specified in External Tools
+	 * Note: This is intended for deep integrations - the LTI Site ID doubles as an identifier for such integrations
+	 * @return Admin / Instructor / Learner as decided by the implementation, or null if this advisor cannot decide
+	 */
+	 public String getLTIRole(String userId, String context, String ltiSiteId);
+}

--- a/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
+++ b/basiclti/basiclti-api/src/java/org/sakaiproject/lti/api/LTIService.java
@@ -677,6 +677,31 @@ public interface LTIService {
 	 */
 	public String formInput(Object row, String[] fieldInfo);
 
+	/**
+	 * Registers an LTIRoleAdvisor against the specified LTI Site Id (as specified in External Tools)
+	 * When the LTI tool with this Site ID is accessed, the advisor will be consulted to determine the user's role
+	 * Note: This is intended for deep integrations - the LTI Site ID doubles as an identifier for such integrations
+	 * @param ltiSiteId the Site ID of the LTI Tool as specified in External Tools
+	 * @param advisor an advisor with an appropriate implementation to determine the LTI role for the given LTI Site ID
+	 */
+	public void registerLTIRoleAdvisor(String ltiSiteId, LTIRoleAdvisor advisor);
+
+	/**
+	 * Consults the appropriate LTIRoleAdvisor to get a user's LTI role
+	 * However, admins will always get the admin role
+	 * @param userId the user whose LTI role we are retrieving. Passing null will resolve to the current session user
+	 * @param context the siteId of the site hosting this LTI instance
+	 * @param ltiSiteId the Site ID of the LTI tool as specified in External Tools
+	 * Note: This is intended for deep integrations - the LTI Site ID doubles as an identifier for such integrations
+	 * @return Admin / Instructor / Learner as appropriate
+	 *
+	 * Note: if no LTIRoleAdvisor is registered for this toolId, or if an advisor is registered but it returns null,
+	 * your role will be determined with this default behavior:
+	 * isSUperUser() - admin;
+	 * user has site.upd ? Instructor : Learner
+	 */
+	public String getLTIRole(String userId, String context, String ltiSiteId);
+
 	// For Instructors, this model is filtered down dynamically based on
 	// Tool settings
 	/**

--- a/basiclti/basiclti-common/pom.xml
+++ b/basiclti/basiclti-common/pom.xml
@@ -75,6 +75,10 @@
                 <artifactId>spring-beans</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
         </dependency>

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -462,21 +462,35 @@ public class SakaiBLTIUtil {
 		Map<String, String> roleMap = convertRoleMapPropToMap(roleMapProp);
 		if (!roleMap.isEmpty())
 		{
-			try {
+			try 
+			{
 				user = UserDirectoryService.getCurrentUser();
-				if ( user != null ) {
+				if ( user != null )
+				{
 					Role role = null;
 					String roleId = null;
 					AuthzGroup realm = ComponentManager.get(AuthzGroupService.class).getAuthzGroup(realmId);
-					if ( realm != null ) role = realm.getUserRole(user.getId());
-					if ( role != null ) roleId = role.getId();
-					if ( roleId != null && roleId.length() > 0 ) setProperty(props, "ext_sakai_role", roleId);
-					if ( roleMap.containsKey(roleId) ) {
+					if ( realm != null )
+					{
+						role = realm.getUserRole(user.getId());
+					}
+					if ( role != null )
+					{
+						roleId = role.getId();
+					}
+					if ( roleId != null && roleId.length() > 0 )
+					{
+						setProperty(props, "ext_sakai_role", roleId);
+					}
+					if ( roleMap.containsKey(roleId) )
+					{
 						setProperty(props, BasicLTIConstants.ROLES, roleMap.get(roleId));
 						setProperty(lti2subst, LTI2Vars.MEMBERSHIP_ROLE, roleMap.get(roleId));
 					}
 				}
-			} catch (GroupNotDefinedException e) {
+			}
+			catch (GroupNotDefinedException e)
+			{
 				dPrint("SiteParticipantHelper.getExternalRealmId: site realm not found"+e.getMessage());
 			}
 		}

--- a/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
+++ b/basiclti/basiclti-common/src/java/org/sakaiproject/basiclti/util/SakaiBLTIUtil.java
@@ -36,6 +36,7 @@ import javax.servlet.http.HttpServletRequest;
 import org.json.simple.JSONObject;
 import org.json.simple.JSONArray;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -446,9 +447,12 @@ public class SakaiBLTIUtil {
 		return theRole;
 	}
 
-	public static void addRoleInfo(Properties props, Properties lti2subst, String context, String roleMapProp)
+	public static void addRoleInfo(Properties props, Properties lti2subst, String context, String roleMapProp, String theRole)
 	{
-		String theRole = getRoleString(context);
+		if (StringUtils.isEmpty(theRole))
+		{
+			theRole = getRoleString(context);
+		}
 
 		setProperty(props,BasicLTIConstants.ROLES,theRole);
 		setProperty(lti2subst,LTI2Vars.MEMBERSHIP_ROLE,theRole);
@@ -456,22 +460,25 @@ public class SakaiBLTIUtil {
 		String realmId = SiteService.siteReference(context);
 		User user = null;
 		Map<String, String> roleMap = convertRoleMapPropToMap(roleMapProp);
-		try {
-			user = UserDirectoryService.getCurrentUser();
-			if ( user != null ) {
-				Role role = null;
-				String roleId = null;
-				AuthzGroup realm = ComponentManager.get(AuthzGroupService.class).getAuthzGroup(realmId);
-				if ( realm != null ) role = realm.getUserRole(user.getId());
-				if ( role != null ) roleId = role.getId();
-				if ( roleId != null && roleId.length() > 0 ) setProperty(props, "ext_sakai_role", roleId);
-				if ( roleMap.containsKey(roleId) ) {
-					setProperty(props, BasicLTIConstants.ROLES, roleMap.get(roleId));
-					setProperty(lti2subst, LTI2Vars.MEMBERSHIP_ROLE, roleMap.get(roleId));
+		if (!roleMap.isEmpty())
+		{
+			try {
+				user = UserDirectoryService.getCurrentUser();
+				if ( user != null ) {
+					Role role = null;
+					String roleId = null;
+					AuthzGroup realm = ComponentManager.get(AuthzGroupService.class).getAuthzGroup(realmId);
+					if ( realm != null ) role = realm.getUserRole(user.getId());
+					if ( role != null ) roleId = role.getId();
+					if ( roleId != null && roleId.length() > 0 ) setProperty(props, "ext_sakai_role", roleId);
+					if ( roleMap.containsKey(roleId) ) {
+						setProperty(props, BasicLTIConstants.ROLES, roleMap.get(roleId));
+						setProperty(lti2subst, LTI2Vars.MEMBERSHIP_ROLE, roleMap.get(roleId));
+					}
 				}
+			} catch (GroupNotDefinedException e) {
+				dPrint("SiteParticipantHelper.getExternalRealmId: site realm not found"+e.getMessage());
 			}
-		} catch (GroupNotDefinedException e) {
-			dPrint("SiteParticipantHelper.getExternalRealmId: site realm not found"+e.getMessage());
 		}
 
 		// Check if there are sections the user is part of (may be more than one)
@@ -516,7 +523,7 @@ public class SakaiBLTIUtil {
 		ToolConfiguration placement = SiteService.findTool(placementId);
 		Properties config = placement.getConfig();
 		String roleMapProp = toNull(getCorrectProperty(config, "rolemap", placement));
-		addRoleInfo(props, null, context, roleMapProp);
+		addRoleInfo(props, null, context, roleMapProp, null);
 		addSiteInfo(props, null, site);
 
 		// Add Placement Information
@@ -857,7 +864,9 @@ public class SakaiBLTIUtil {
 		}
 		addGlobalData(site, ltiProps, lti2subst, rb);
 		addSiteInfo(ltiProps, lti2subst, site);
-		addRoleInfo(ltiProps, lti2subst,  context, (String)tool.get("rolemap"));
+		String siteId = (String)tool.get(LTIService.LTI_SITE_ID);
+		String role = ltiService.getLTIRole(null, context, siteId);
+		addRoleInfo(ltiProps, lti2subst,  context, (String)tool.get("rolemap"), role);
 		addUserInfo(ltiProps, lti2subst, tool);
 
 
@@ -1385,7 +1394,7 @@ public class SakaiBLTIUtil {
 
 		addGlobalData(site, ltiProps, lti2subst, rb);
 		addSiteInfo(ltiProps, lti2subst, site);
-		addRoleInfo(ltiProps, lti2subst,  context, (String)tool.get("rolemap"));
+		addRoleInfo(ltiProps, lti2subst,  context, (String)tool.get("rolemap"), null);
 
 		int releasename = getInt(tool.get(LTIService.LTI_SENDNAME));
 		int releaseemail = getInt(tool.get(LTIService.LTI_SENDEMAILADDR));

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -67,7 +67,7 @@ public abstract class BaseLTIService implements LTIService {
 	public final String LAUNCH_PREFIX = "/access/basiclti/site/";
 
 	/** Maps LTI Site Ids (as specified in External Tools) to their corresponding LTIRoleAdvisors */
-	private static final Map<String, LTIRoleAdvisor> roleAdvisors = new HashMap<String, LTIRoleAdvisor>();
+	private static final Map<String, LTIRoleAdvisor> roleAdvisors = new HashMap<>();
 
 	/** Resource bundle using current language locale */
 	protected static ResourceLoader rb = new ResourceLoader("ltiservice");

--- a/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
+++ b/basiclti/basiclti-impl/src/java/org/sakaiproject/lti/impl/BaseLTIService.java
@@ -21,10 +21,12 @@
 
 package org.sakaiproject.lti.impl;
 
+import java.util.HashMap;
 import java.util.UUID;
 import java.util.List;
 import java.util.Map;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.sakaiproject.authz.api.SecurityService;
@@ -33,6 +35,7 @@ import org.sakaiproject.event.api.EventTrackingService;
 import org.sakaiproject.event.api.UsageSessionService;
 import org.sakaiproject.exception.IdUnusedException;
 import org.sakaiproject.exception.PermissionException;
+import org.sakaiproject.lti.api.LTIRoleAdvisor;
 import org.sakaiproject.lti.api.LTIService;
 import org.sakaiproject.site.api.SiteService;
 import org.sakaiproject.site.api.Site;
@@ -40,9 +43,11 @@ import org.sakaiproject.site.api.SitePage;
 import org.sakaiproject.site.api.ToolConfiguration;
 import org.sakaiproject.tool.api.SessionManager;
 import org.sakaiproject.tool.api.ToolManager;
+import org.sakaiproject.user.api.User;
 import org.sakaiproject.user.api.UserDirectoryService;
 import org.sakaiproject.util.ResourceLoader;
 import org.sakaiproject.util.foorm.SakaiFoorm;
+import org.tsugi.lti2.LTI2Vars;
 
 import java.util.ArrayList;
 import java.util.Map;
@@ -60,6 +65,9 @@ public abstract class BaseLTIService implements LTIService {
 	/** Constants */
 	private final String ADMIN_SITE = "!admin";
 	public final String LAUNCH_PREFIX = "/access/basiclti/site/";
+
+	/** Maps LTI Site Ids (as specified in External Tools) to their corresponding LTIRoleAdvisors */
+	private static final Map<String, LTIRoleAdvisor> roleAdvisors = new HashMap<String, LTIRoleAdvisor>();
 
 	/** Resource bundle using current language locale */
 	protected static ResourceLoader rb = new ResourceLoader("ltiservice");
@@ -880,6 +888,54 @@ public abstract class BaseLTIService implements LTIService {
 			M_log.warn(this + " LTI content="+key+" placement="+tool.getId()+" could not remove page from site=" + siteStr);
 			return new String(rb.getFormattedMessage("error.link.placement.update", new Object[]{key.toString()}));
 		}
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public void registerLTIRoleAdvisor(String ltiSiteId, LTIRoleAdvisor advisor)
+	{
+		roleAdvisors.put(ltiSiteId, advisor);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public String getLTIRole(String userId, String context, String ltiSiteId)
+	{
+		if (securityService.isSuperUser())
+		{
+			return LTI2Vars.MEMBERSHIP_ROLE_INSTRUCTOR+",Administrator,urn:lti:instrole:ims/lis/Administrator,urn:lti:sysrole:ims/lis/Administrator";
+		}
+		String role = null;
+
+		if (StringUtils.isEmpty(userId))
+		{
+			User user = m_userDirectoryService.getCurrentUser();
+			if (user == null)
+			{
+				// User is not authenticated; "Learner" is default behavior
+				return LTI2Vars.MEMBERSHIP_ROLE_LEARNER;
+			}
+			else
+			{
+				userId = user.getId();
+			}
+		}
+
+		// Consult the appropriate role advisor if one exists
+		LTIRoleAdvisor advisor = roleAdvisors.get(ltiSiteId);
+		if (advisor != null)
+		{
+			role = advisor.getLTIRole(userId, context, ltiSiteId);
+			if (!StringUtils.isEmpty(role))
+			{
+				return role;
+			}
+		}
+
+		// Default behavior: has site.upd -> instructor, else -> learner
+		return siteService.allowUpdateSite(context) ? LTI2Vars.MEMBERSHIP_ROLE_INSTRUCTOR : LTI2Vars.MEMBERSHIP_ROLE_LEARNER;
 	}
 
 	// The methods for deployment objects


### PR DESCRIPTION
https://jira.sakaiproject.org/browse/TII-227

By default, basiclti determines your role as follows:
isSuperUser() -> admin;
has site.upd ? Instructor : Learner
In the case of TII, your role should be Instructor iff you have asn.grade rather than site.upd. But we don't want to hard-code a TII integration specific check for asn.grade in basiclti. Keep this role-determining logic separated by adding a mechanism to register a new interface called 'LTIRoleAdvisor' into the LTIService which determines your LTI role, then keep the TII specific implementation in content-review-impl.